### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0+9] - January 9, 2024
+
+* Automated dependency updates
+
+
 ## [4.0.0+8] - December 12, 2023
 
 * Automated dependency updates
@@ -311,6 +316,7 @@
 ## [1.0.0+1] - December 1st, 2021
 
 * Initial release
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+6'
+version: '1.0.0+7'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -9,7 +9,7 @@ environment:
 dependencies: 
   flutter: 
     sdk: 'flutter'
-  json_dynamic_widget: '^7.0.6+1'
+  json_dynamic_widget: '^7.0.6+4'
   json_dynamic_widget_plugin_material_icons: 
     path: '../'
   json_theme: '^6.4.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_plugin_material_icons'
 description: 'A plugin to the JSON Dynamic Widget to provide String name support for Material Icons'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_material_icons'
-version: '4.0.0+8'
+version: '4.0.0+9'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -16,13 +16,13 @@ dependencies:
   child_builder: '^2.0.2'
   flutter: 
     sdk: 'flutter'
-  json_class: '^3.0.0+9'
-  json_dynamic_widget: '^7.0.6+1'
+  json_class: '^3.0.0+10'
+  json_dynamic_widget: '^7.0.6+4'
   json_theme: '^6.4.0'
   logging: '^1.2.0'
   material_icons_named: '^3.16.0'
   meta: '^1.9.1'
-  uuid: '^4.2.1'
+  uuid: '^4.3.1'
 
 false_secrets: 
   - 'example/web/index.html'
@@ -32,7 +32,7 @@ dev_dependencies:
   flutter_lints: '^3.0.1'
   flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.4+3'
+  json_dynamic_widget_codegen: '^1.0.5+1'
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_class`: 3.0.0+9 --> 3.0.0+10
  * `json_dynamic_widget`: 7.0.6+1 --> 7.0.6+4
  * `uuid`: 4.2.1 --> 4.3.1

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.4+3 --> 1.0.5+1


Error!!!
```
Resolving dependencies...
  _fe_analyzer_shared 64.0.0 (65.0.0 available)
  analyzer 6.2.0 (6.3.0 available)
  archive 3.3.2 (3.4.10 available)
  built_value 8.6.3 (8.8.1 available)
  cli_config 0.1.1 (0.1.2 available)
  coverage 1.6.3 (1.7.2 available)
  dds 2.9.5 (3.1.2 available)
  dds_service_extensions 1.6.0 (1.6.3 available)
  devtools_shared 2.26.1 (6.0.3 available)
  dwds 21.0.0 (23.1.0 available)
  file 6.1.4 (7.0.0 available)
  flutter_template_images 4.2.0 (4.2.1 available)
  http 0.13.6 (1.1.2 available)
  intl 0.18.1 (0.19.0 available)
  js 0.6.7 (0.7.0 available)
  matcher 0.12.16 (0.12.16+1 available)
  meta 1.10.0 (1.11.0 available)
  multicast_dns 0.3.2+4 (0.3.2+6 available)
  native_assets_builder 0.2.3 (0.3.0 available)
  native_assets_cli 0.2.0 (0.3.2 available)
  path 1.8.3 (1.9.0 available)
  petitparser 6.0.1 (6.0.2 available)
  platform 3.1.2 (3.1.4 available)
  process 4.2.4 (5.0.2 available)
  sse 4.1.2 (4.1.4 available)
  test 1.24.6 (1.25.0 available)
  test_api 0.6.1 (0.7.0 available)
  test_core 0.5.6 (0.6.0 available)
  unified_analytics 4.0.0 (5.8.0 available)
  uuid 3.0.7 (4.3.1 available)
  vm_service 11.10.0 (14.0.0 available)
  web_socket_channel 2.4.0 (2.4.3 available)
  webdriver 3.0.2 (3.0.3 available)
  xml 6.4.2 (6.5.0 available)
No dependencies changed.
34 packages have newer versions incompatible with dependency constraints.
Try `dart pub outdated` for more information.
Resolving dependencies...


Building flutter tool...
Note: meta is pinned to version 1.10.0 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter_test from sdk depends on meta 1.10.0 and uuid >=4.3.0 depends on meta ^1.11.0, flutter_test from sdk is incompatible with uuid >=4.3.0.
So, because json_dynamic_widget_plugin_material_icons depends on both uuid ^4.3.1 and flutter_test from sdk, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on uuid: flutter pub add uuid:^4.2.2

```


dependencies:
  * `json_dynamic_widget`: 7.0.6+1 --> 7.0.6+4


Error!!!
```
Resolving dependencies...


Note: meta is pinned to version 1.10.0 by flutter from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter from sdk depends on meta 1.10.0 and uuid >=4.3.0 depends on meta ^1.11.0, flutter from sdk is incompatible with uuid >=4.3.0.
And because every version of json_dynamic_widget_plugin_material_icons from path depends on uuid ^4.3.1, flutter from sdk is incompatible with json_dynamic_widget_plugin_material_icons from path.
So, because example depends on both flutter from sdk and json_dynamic_widget_plugin_material_icons from path, version solving failed.

```

