### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.0+21] - May 28, 2024
+
+* Automated dependency updates
+
+
 ## [4.0.0+20] - April 30, 2024
 
 * Automated dependency updates
@@ -371,65 +376,3 @@
 ## [1.0.0+1] - December 1st, 2021
 
 * Initial release
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+17'
+version: '1.0.0+18'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -9,12 +9,12 @@ environment:
 dependencies: 
   flutter: 
     sdk: 'flutter'
-  json_dynamic_widget: '^7.1.0+7'
+  json_dynamic_widget: '^7.2.0+2'
   json_dynamic_widget_plugin_material_icons: 
     path: '../'
-  json_theme: '^6.4.1+5'
+  json_theme: '^6.5.0+1'
   logging: '^1.2.0'
-  material_icons_named: '^3.16.0'
+  material_icons_named: '^3.16.0+1'
 
 dev_dependencies: 
   flutter_test: 
@@ -25,33 +25,27 @@ flutter:
   assets: 
     - 'assets/pages/'
 
-permittedLicenses:
-  - Apache-2.0
-  - BSD-2-Clause
-  - BSD-3-Clause
-  - MIT
-  - MIT-Modern-Variant
-  - MPL-2.0
-  - Zlib
+permittedLicenses: 
+  - 'Apache-2.0'
+  - 'BSD-2-Clause'
+  - 'BSD-3-Clause'
+  - 'MIT'
+  - 'MIT-Modern-Variant'
+  - 'MPL-2.0'
+  - 'Zlib'
 
-# The [license_checker](https://pub.dev/packages/license_checker) package cannot
-# detect the built in Flutter packages because they aren't published to pub.dev
-# and do not have a LICENSE file in their respective folders.  So this section
-# informs the license_checker that all the built in Flutter packages all have
-# the same BSD-3-Clause license as Flutter itself. 
 packageLicenseOverride: 
-  flutter: BSD-3-Clause
-  flutter_driver: BSD-3-Clause
-  flutter_goldens: BSD-3-Clause
-  flutter_localizations: BSD-3-Clause
-  flutter_web_plugins: BSD-3-Clause
-  flutter_test: BSD-3-Clause
-  fuchsia_remote_debug_protocol: BSD-3-Clause
-  integration_test: BSD-3-Clause
-  rxdart: Apache-2.0
+  flutter: 'BSD-3-Clause'
+  flutter_driver: 'BSD-3-Clause'
+  flutter_goldens: 'BSD-3-Clause'
+  flutter_localizations: 'BSD-3-Clause'
+  flutter_web_plugins: 'BSD-3-Clause'
+  flutter_test: 'BSD-3-Clause'
+  fuchsia_remote_debug_protocol: 'BSD-3-Clause'
+  integration_test: 'BSD-3-Clause'
+  rxdart: 'Apache-2.0'
 
-ignore_updates:
- 
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_plugin_material_icons'
 description: 'A plugin to the JSON Dynamic Widget to provide String name support for Material Icons'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget_plugin_material_icons'
-version: '4.0.0+20'
+version: '4.0.0+21'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -16,10 +16,10 @@ dependencies:
   flutter: 
     sdk: 'flutter'
   json_class: '^3.0.0+13'
-  json_dynamic_widget: '^7.1.0+7'
-  json_theme: '^6.4.1+5'
+  json_dynamic_widget: '^7.2.0+2'
+  json_theme: '^6.5.0+1'
   logging: '^1.2.0'
-  material_icons_named: '^3.16.0'
+  material_icons_named: '^3.16.0+1'
   meta: '^1.12.0'
   uuid: '^4.4.0'
 
@@ -27,39 +27,33 @@ false_secrets:
   - 'example/web/index.html'
 
 dev_dependencies: 
-  build_runner: '^2.4.9'
-  flutter_lints: '^3.0.2'
+  build_runner: '^2.4.10'
+  flutter_lints: '^4.0.0'
   flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.5+8'
+  json_dynamic_widget_codegen: '^1.0.6+1'
 
-permittedLicenses:
-  - Apache-2.0
-  - BSD-2-Clause
-  - BSD-3-Clause
-  - MIT
-  - MIT-Modern-Variant
-  - MPL-2.0
-  - Zlib
+permittedLicenses: 
+  - 'Apache-2.0'
+  - 'BSD-2-Clause'
+  - 'BSD-3-Clause'
+  - 'MIT'
+  - 'MIT-Modern-Variant'
+  - 'MPL-2.0'
+  - 'Zlib'
 
-# The [license_checker](https://pub.dev/packages/license_checker) package cannot
-# detect the built in Flutter packages because they aren't published to pub.dev
-# and do not have a LICENSE file in their respective folders.  So this section
-# informs the license_checker that all the built in Flutter packages all have
-# the same BSD-3-Clause license as Flutter itself. 
 packageLicenseOverride: 
-  flutter: BSD-3-Clause
-  flutter_driver: BSD-3-Clause
-  flutter_goldens: BSD-3-Clause
-  flutter_localizations: BSD-3-Clause
-  flutter_web_plugins: BSD-3-Clause
-  flutter_test: BSD-3-Clause
-  fuchsia_remote_debug_protocol: BSD-3-Clause
-  integration_test: BSD-3-Clause
-  rxdart: Apache-2.0
+  flutter: 'BSD-3-Clause'
+  flutter_driver: 'BSD-3-Clause'
+  flutter_goldens: 'BSD-3-Clause'
+  flutter_localizations: 'BSD-3-Clause'
+  flutter_web_plugins: 'BSD-3-Clause'
+  flutter_test: 'BSD-3-Clause'
+  fuchsia_remote_debug_protocol: 'BSD-3-Clause'
+  integration_test: 'BSD-3-Clause'
+  rxdart: 'Apache-2.0'
 
-ignore_updates:
- 
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_dynamic_widget`: 7.1.0+7 --> 7.2.0+2
  * `json_theme`: 6.4.1+5 --> 6.5.0+1
  * `material_icons_named`: 3.16.0 --> 3.16.0+1

dev_dependencies:
  * `build_runner`: 2.4.9 --> 2.4.10
  * `flutter_lints`: 3.0.2 --> 4.0.0
  * `json_dynamic_widget_codegen`: 1.0.5+8 --> 1.0.6+1


Analysis Successful


dependencies:
  * `json_dynamic_widget`: 7.1.0+7 --> 7.2.0+2
  * `json_theme`: 6.4.1+5 --> 6.5.0+1
  * `material_icons_named`: 3.16.0 --> 3.16.0+1


Analysis Successful

